### PR TITLE
Make AccessDeniedError unchecked, update error response

### DIFF
--- a/src/main/java/com/fleetpin/graphql/aws/lambda/LambdaGraphQL.java
+++ b/src/main/java/com/fleetpin/graphql/aws/lambda/LambdaGraphQL.java
@@ -22,7 +22,6 @@ import com.fleetpin.graphql.builder.SchemaBuilder;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 
-import com.google.common.collect.ImmutableMap;
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.GraphQL;
@@ -133,7 +132,7 @@ public abstract class LambdaGraphQL<U, C extends ContextGraphQL> implements Requ
                 if(showFailureCause()) {
                 	requestFailedResponse.setBody(Throwables.getStackTraceAsString(e));
                 }else {
-                	requestFailedResponse.setBody("Internal Server Error");
+                	requestFailedResponse.setBody("{ \"error\": \"Internal Server Error\" }");
                 }
                 return requestFailedResponse;
             }

--- a/src/main/java/com/fleetpin/graphql/aws/lambda/exceptions/AccessDeniedError.java
+++ b/src/main/java/com/fleetpin/graphql/aws/lambda/exceptions/AccessDeniedError.java
@@ -7,7 +7,7 @@ import graphql.language.SourceLocation;
 
 import java.util.List;
 
-public class AccessDeniedError extends Exception implements GraphQLError {
+public class AccessDeniedError extends RuntimeException implements GraphQLError {
     private static final String DEFAULT_MESSAGE = AccessDeniedError.class.getSimpleName();
     private final String message;
 


### PR DESCRIPTION
Couple of changes to help us (as an end user of the library) handle errors. Happy to talk them through or change them as you guys see fit:

- Made AccessDeniedError unchecked as trying to use the checked version was leading to issues for us
- Updated the error message when a 500 is thrown to be JSON, in line with what the response header is configured to.