### PR TITLE
Update MAPPER

### DIFF
--- a/src/main/java/com/fleetpin/graphql/aws/lambda/LambdaGraphQL.java
+++ b/src/main/java/com/fleetpin/graphql/aws/lambda/LambdaGraphQL.java
@@ -18,11 +18,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fleetpin.graphql.aws.lambda.exceptions.AccessDeniedError;
-import com.fleetpin.graphql.builder.SchemaBuilder;
+import com.fleetpin.graphql.aws.lambda.util.InputMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 
-import com.google.common.collect.ImmutableMap;
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.GraphQL;
@@ -185,7 +184,7 @@ public abstract class LambdaGraphQL<U, C extends ContextGraphQL> implements Requ
     }
 
     protected ObjectMapper builderObjectMapper() {
-        return SchemaBuilder.MAPPER;
+        return InputMapper.MAPPER;
     }
 
     protected abstract GraphQL buildGraphQL() throws Exception;

--- a/src/main/java/com/fleetpin/graphql/aws/lambda/util/InputMapper.java
+++ b/src/main/java/com/fleetpin/graphql/aws/lambda/util/InputMapper.java
@@ -10,9 +10,30 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import com.fleetpin.graphql.builder.annotations.GraphQLIgnore;
 
 public class InputMapper {
+	
+	
+	public static final ObjectMapper MAPPER = new ObjectMapper()
+			.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+			.registerModule(new ParameterNamesModule())
+			.registerModule(new Jdk8Module())
+			.registerModule(new JavaTimeModule())
+			.disable(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+			.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+			.disable(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)
+			.disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
+			.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
 
 	public static void assign(Object existing, Object input) {
 		try {


### PR DESCRIPTION
SchemaBuilder.MAPPER doesn't exist any more, have pulled what we need into this code. Can also update constructor to take a mapper as an argument if you think that makes more sense.